### PR TITLE
Handle rotation

### DIFF
--- a/addons/editor_handles/editor_handles_control.gd
+++ b/addons/editor_handles/editor_handles_control.gd
@@ -213,6 +213,9 @@ func resize_expand_center_drag_handle_to(handle, new_position):
 
 func resize_sides_drag_handle_to(handle, mouse_global_pos):
 	var grot = get_global_transform().affine_inverse().get_rotation()
+	if(grot != 0.0):
+		push_error("Resizing with rotated bodies is only supported with 'expand from center' on.  I just haven't figured it out yet and it goes crazy-go-nuts.")
+		return
 	var diff = mouse_global_pos - (global_position + handle.rect.position)
 	size += diff * handle.get_center().sign()
 	if(eh.lock_x):
@@ -220,8 +223,7 @@ func resize_sides_drag_handle_to(handle, mouse_global_pos):
 	if(eh.lock_y):
 		diff.y = 0
 
-	var pos_change :Vector2 = (diff / 2.0) * handle.get_center().sign().abs()
-
+	var pos_change : Vector2 = (diff / 2.0) * handle.get_center().sign().abs()
 	position += pos_change
 	eh.position = position
 
@@ -234,6 +236,14 @@ func print_info():
 		print("  ", key, "  l: ", _handles[key].get_center(), ' g: ', _handles[key].get_center() + position)
 # --------------------
 #endregion
+
+
+func _translate_glob_pos(glob_pos):
+	var viewport_transform_inverted = get_viewport().get_global_canvas_transform().affine_inverse()
+	var viewport_position = viewport_transform_inverted.basis_xform(glob_pos)
+	var global_transform_inverted = get_global_transform().affine_inverse()
+	var target_position = global_transform_inverted.basis_xform(viewport_position).round() # pixel perfect positions
+	return target_position
 
 
 

--- a/ideas.md
+++ b/ideas.md
@@ -14,6 +14,7 @@
 * Expand from center option.  Currently it is "expand from center", but it should get an option and have more handles so it can be used both ways.
 * when resizing sides, undo should contain a size and position value, otherwise undo doesn't undo the move.
 * hide or visibly disable handles when lock_x or lock_y would prevent them from being used.
+* Do I need to honor the currently selected editor mode (move, resize, rotate, scale, etc)?
 
 
 # Handle drawing resource
@@ -53,3 +54,10 @@ Allows you to make a tool node that has parts that can be resized and moved whil
 - GoditorRect
 - LessEditableChildren
 - EditorHandles
+
+
+# Reference Material
+GDQuest:   How to Create a 2d Manipulator in Godot 3.1: Editor Plugin Overview
+https://www.youtube.com/watch?v=H6TfKYtuM9U
+GDQuest:  Canvas Input, Undo, and Redo in Godot: Plugin Tutorial 2
+https://www.youtube.com/watch?v=RDx5B_AzkPI

--- a/test/manual/resizable_texture_rect.gd
+++ b/test/manual/resizable_texture_rect.gd
@@ -6,6 +6,7 @@ extends Node2D
 
 func _ready():
 	if(Engine.is_editor_hint()):
+		resize_properties.changed.connect(_apply_resize_properties)
 		# Example of having to override properties that have already been set
 		# in instances because we didn't disable them in time.
 		#resize_properties.moveable = false
@@ -13,12 +14,15 @@ func _ready():
 		# ----
 		#resize_properties.set_hidden_instance_properties(["moveable"])
 		#resize_properties.set_disabled_instance_properties(["position"])
-		resize_properties.editor_setup(self)
-		resize_properties.changed.connect(_on_resize_properties_changed)
-	_on_resize_properties_changed()
+		var ctrl = resize_properties.editor_setup(self)
+		
+		#ctrl.rotation_degrees = 90
+		ctrl._handles.ct.color = Color.RED
+		print(ctrl.global_transform, rad_to_deg(ctrl.global_transform.get_rotation()))
+	_apply_resize_properties()
 
 
-func _on_resize_properties_changed():
+func _apply_resize_properties():
 	resize_properties.size = resize_properties.size.max($TextureRect.texture.get_size())
 	$TextureRect.size = resize_properties.size
 	$TextureRect.position = resize_properties.position - $TextureRect.size / 2

--- a/test/manual/resizable_texture_rect.tscn
+++ b/test/manual/resizable_texture_rect.tscn
@@ -9,24 +9,23 @@ resource_local_to_scene = true
 script = ExtResource("2_qagh0")
 expand_from_center = false
 resizable = true
-size = Vector2(812.303, 714.585)
+size = Vector2(694, 348)
 lock_x = false
 lock_x_value = 150
 lock_y = false
 lock_y_value = 150
 moveable = true
-position = Vector2(-12.3089, -96.3433)
+position = Vector2(6.59863, -55.4)
 drag_snap = Vector2(1, 1)
 
 [node name="ResizableTextureRect" type="Node2D"]
 position = Vector2(400, 400)
-rotation = 0.575959
 script = ExtResource("1_ug7y2")
 resize_properties = SubResource("Resource_nxr5t")
 
 [node name="TextureRect" type="TextureRect" parent="."]
-offset_left = -418.46
-offset_top = -453.636
-offset_right = 393.842
-offset_bottom = 260.949
+offset_left = -340.401
+offset_top = -229.4
+offset_right = 353.599
+offset_bottom = 118.6
 texture = ExtResource("1_6urua")

--- a/test/manual/resizable_texture_rect.tscn
+++ b/test/manual/resizable_texture_rect.tscn
@@ -7,25 +7,26 @@
 [sub_resource type="Resource" id="Resource_nxr5t"]
 resource_local_to_scene = true
 script = ExtResource("2_qagh0")
-expand_from_center = true
+expand_from_center = false
 resizable = true
-size = Vector2(150, 352)
-lock_x = true
+size = Vector2(812.303, 714.585)
+lock_x = false
 lock_x_value = 150
 lock_y = false
 lock_y_value = 150
-moveable = false
-position = Vector2(0, -19)
+moveable = true
+position = Vector2(-12.3089, -96.3433)
 drag_snap = Vector2(1, 1)
 
 [node name="ResizableTextureRect" type="Node2D"]
 position = Vector2(400, 400)
+rotation = 0.575959
 script = ExtResource("1_ug7y2")
 resize_properties = SubResource("Resource_nxr5t")
 
 [node name="TextureRect" type="TextureRect" parent="."]
-offset_left = -75.0
-offset_top = -195.0
-offset_right = 75.0
-offset_bottom = 157.0
+offset_left = -418.46
+offset_top = -453.636
+offset_right = 393.842
+offset_bottom = 260.949
 texture = ExtResource("1_6urua")

--- a/test/unit/test_editor_handles_control.gd
+++ b/test/unit/test_editor_handles_control.gd
@@ -159,8 +159,49 @@ func test_resize_sides_lock_y(p = use_parameters(_resize_size_drag_params)):
 	assert_eq(ehc.eh.position, ehc.position, 'upstream updated')
 
 
+var _resize_size_rotated_drag_params = ParameterFactory.named_parameters(
+	['handle_key', 'rotation', 'move_by', 'new_size', 'new_position'],[
+	['tl', 90, Vector2(-20, -20), Vector2(120, 120), Vector2(190, 190)],
+
+	# ['tl', 0, Vector2(4, 4), Vector2(96, 96), Vector2(202, 202)],
+
+	# ['br', 0, Vector2(4, 4), Vector2(104, 104), Vector2(202, 202)],
+
+	# ['cr', 0, Vector2(4, 4), Vector2(104, 100), Vector2(202, 200)],
+
+	# ['bl', 0, Vector2(-4, 4), Vector2(104, 104), Vector2(198, 202)],
+
+	# ['cb', 0, Vector2(-4, 4), Vector2(100, 104), Vector2(200, 202)],
+	# ['cb', 0, Vector2(200, -20), Vector2(100, 80), Vector2(200, 190)],
+
+	# ['tr', 0, Vector2(4, -4), Vector2(104, 104), Vector2(202, 198)],
+	# ['tr', 0, Vector2(-4, 4), Vector2(96, 96), Vector2(198, 202)]
+])
+func test_resize_sides_when_rotated(p = use_parameters(_resize_size_rotated_drag_params)):
+	var eh = EditorHandles.new()
+	eh.position = Vector2(200, 200)
+	eh.size = Vector2(100, 100)
+	eh.expand_from_center = false
+	eh.moveable = true
+
+	var ehc = _new_editor_handles_control(eh)
+	ehc.rotation_degrees = p.rotation
+	ehc._handles.ct.color = Color.RED
+	ehc._handles[p.handle_key].color = Color.BLUE
+	ehc.queue_redraw()
+
+	# await wait_seconds(1)
+	_resize_sides_drag_handle_by(ehc, ehc._handles[p.handle_key], p.move_by)
+	# await wait_seconds(1)
+	assert_almost_eq(ehc.size, p.new_size, Vector2(.1, .1),'size')
+	assert_almost_eq(ehc.position, p.new_position, Vector2(.1, .1), 'position')
+	assert_eq(ehc.eh.position, ehc.position, 'upstream updated')
 
 
+# --------------------
+#endregion
+# region resize expand center
+# --------------------
 
 func _resize_expand_center_drag_handle_by(ehc, handle, movement):
 	var hdl_glob_pos = handle.get_center() + ehc.position
@@ -220,3 +261,6 @@ func test_resize_expand_center_lock_height(p = use_parameters(_resize_expand_cen
 
 	_resize_expand_center_drag_handle_by(ehc, ehc._handles[p.handle_key], p.move_by)
 	assert_eq(ehc.size, check_size, 'size')
+
+# --------------------
+#endregion

--- a/test/unit/test_editor_handles_control.gd
+++ b/test/unit/test_editor_handles_control.gd
@@ -95,20 +95,15 @@ var _resize_size_drag_params = ParameterFactory.named_parameters(
 	['handle_key', 'move_by', 'new_size', 'new_position'],[
 	['tl', Vector2(-4, -4), Vector2(104, 104), Vector2(198, 198)],
 	['tl', Vector2(4, 4), Vector2(96, 96), Vector2(202, 202)],
-
 	['br',Vector2(4, 4), Vector2(104, 104), Vector2(202, 202)],
-
 	['cr', Vector2(4, 4), Vector2(104, 100), Vector2(202, 200)],
-
 	['bl', Vector2(-4, 4), Vector2(104, 104), Vector2(198, 202)],
-
 	['cb', Vector2(-4, 4), Vector2(100, 104), Vector2(200, 202)],
 	['cb', Vector2(200, -20), Vector2(100, 80), Vector2(200, 190)],
-
 	['tr', Vector2(4, -4), Vector2(104, 104), Vector2(202, 198)],
 	['tr', Vector2(-4, 4), Vector2(96, 96), Vector2(198, 202)]
 ])
-func test_resize_sides(p = use_parameters(_resize_size_drag_params)):
+func test_resize_sides_basic(p = use_parameters(_resize_size_drag_params)):
 	var eh = EditorHandles.new()
 	eh.position = Vector2(200, 200)
 	eh.size = Vector2(100, 100)
@@ -160,20 +155,15 @@ func test_resize_sides_lock_y(p = use_parameters(_resize_size_drag_params)):
 
 
 var _resize_size_rotated_drag_params = ParameterFactory.named_parameters(
-	['handle_key', 'rotation', 'move_by', 'new_size', 'new_position'],[
-	['tl', 90, Vector2(-20, -20), Vector2(120, 120), Vector2(190, 190)],
+	['handle_key', 'rotation', 'move_by', 'new_size', 'new_position', 'pause'],[
+	['tl', 90, Vector2(-20, -20), Vector2(120, 120), Vector2(210, 190)],
+	['br', 90, Vector2(20, 20), Vector2(120, 120), Vector2(190, 210), true],
 
 	# ['tl', 0, Vector2(4, 4), Vector2(96, 96), Vector2(202, 202)],
-
-	# ['br', 0, Vector2(4, 4), Vector2(104, 104), Vector2(202, 202)],
-
 	# ['cr', 0, Vector2(4, 4), Vector2(104, 100), Vector2(202, 200)],
-
 	# ['bl', 0, Vector2(-4, 4), Vector2(104, 104), Vector2(198, 202)],
-
 	# ['cb', 0, Vector2(-4, 4), Vector2(100, 104), Vector2(200, 202)],
 	# ['cb', 0, Vector2(200, -20), Vector2(100, 80), Vector2(200, 190)],
-
 	# ['tr', 0, Vector2(4, -4), Vector2(104, 104), Vector2(202, 198)],
 	# ['tr', 0, Vector2(-4, 4), Vector2(96, 96), Vector2(198, 202)]
 ])
@@ -190,9 +180,11 @@ func test_resize_sides_when_rotated(p = use_parameters(_resize_size_rotated_drag
 	ehc._handles[p.handle_key].color = Color.BLUE
 	ehc.queue_redraw()
 
-	# await wait_seconds(1)
+	if(p.pause == true):
+		await wait_seconds(1)
 	_resize_sides_drag_handle_by(ehc, ehc._handles[p.handle_key], p.move_by)
-	# await wait_seconds(1)
+	if(p.pause == true):
+		await wait_seconds(1)
 	assert_almost_eq(ehc.size, p.new_size, Vector2(.1, .1),'size')
 	assert_almost_eq(ehc.position, p.new_position, Vector2(.1, .1), 'position')
 	assert_eq(ehc.eh.position, ehc.position, 'upstream updated')


### PR DESCRIPTION
Resizing with expand-from-center works with rotation.  Resizing sides does not work so I've disabled resizing from sides if there is any rotation.  An error is generated.  I'll get back to this later, it's very annoying as I have no idea what I'm doing.