### PR TITLE
Hide unusable handles

### DIFF
--- a/addons/editor_handles/editor_handles.gd
+++ b/addons/editor_handles/editor_handles.gd
@@ -36,6 +36,7 @@ var _disabled_props := []
 		if(lock_x):
 			size.x = lock_x_value
 			_apply_properties_to_handles_ctrl()
+		_disable_handles_for_locks()
 		_emit_signals([changed])
 
 ## The locked width value
@@ -53,6 +54,7 @@ var _disabled_props := []
 		lock_y = val
 		if(lock_y):
 			size.y = lock_y_value
+		_disable_handles_for_locks()
 		_emit_signals([changed])
 
 ## The locked height value
@@ -147,6 +149,18 @@ func _emit_signals(signal_list : Array[Signal]):
 		_is_currently_setting_property = false
 
 
+func _disable_handles_for_locks():
+	if(_handles_ctrl != null):
+		for key in ['tl', 'tr','br', 'bl']:
+			_handles_ctrl._handles[key].disabled = lock_x or lock_y
+
+		for key in ['cr', 'cl']:
+			_handles_ctrl._handles[key].disabled = lock_x
+
+		for key in ['ct', 'cb']:
+			_handles_ctrl._handles[key].disabled = lock_y
+
+
 ## Call this in ready.  You probably want to call this only when
 ## `Engine.is_editor_hint()` is true, but it won't hurt anything if you do it
 ## all the time.
@@ -163,6 +177,7 @@ func editor_setup(for_what):
 	moved.emit()
 	_handles_ctrl = to_return
 	for_what.add_child(to_return)
+	_disable_handles_for_locks()
 	return to_return
 
 

--- a/addons/editor_handles/editor_handles_control.gd
+++ b/addons/editor_handles/editor_handles_control.gd
@@ -5,7 +5,7 @@ class_name EditorHandlesControl
 class SideHandle:
 	var color = Color.ORANGE
 	var color2 = Color.BLUE
-
+	var disabled = false
 	var active = false
 	# Local position.
 	var rect = Rect2(Vector2.ZERO, Vector2(20, 20))
@@ -14,10 +14,11 @@ class SideHandle:
 		return rect.position + rect.size / 2
 
 	func draw(draw_on):
-		var c = color
-		if(active):
-			c = color2
-		draw_on.draw_rect(rect, c)
+		if(!disabled):
+			var c = color
+			if(active):
+				c = color2
+			draw_on.draw_rect(rect, c)
 
 
 
@@ -124,7 +125,6 @@ func _update_handles():
 		_handles[key].rect.position -= _handles[key].rect.size / 2
 
 
-
 func _handle_move_for_mouse_motion(new_position):
 	global_position = new_position
 	eh.position = position
@@ -139,6 +139,8 @@ func _get_first_handle_containing_point(point):
 		if(h.rect.has_point(point)):
 			to_return = h
 		idx += 1
+	if(to_return != null and to_return.disabled):
+		to_return = null
 	return to_return
 
 

--- a/addons/editor_handles/editor_handles_control.gd
+++ b/addons/editor_handles/editor_handles_control.gd
@@ -57,7 +57,8 @@ var _handles = {
 	bl = SideHandle.new(),
 	cl = SideHandle.new()
 }
-var _focused_handle = null :
+
+var _focused_handle : SideHandle = null :
 	set(val):
 		if(_focused_handle != null):
 			_focused_handle.active = false

--- a/test/manual/resizable_texture_rect.tscn
+++ b/test/manual/resizable_texture_rect.tscn
@@ -9,13 +9,13 @@ resource_local_to_scene = true
 script = ExtResource("2_qagh0")
 expand_from_center = true
 resizable = true
-size = Vector2(150, 744)
-lock_x = true
+size = Vector2(150, 150)
+lock_x = false
 lock_x_value = 150
 lock_y = false
 lock_y_value = 150
 moveable = true
-position = Vector2(-2.40186, 0.600006)
+position = Vector2(0, 0)
 drag_snap = Vector2(1, 1)
 
 [node name="ResizableTextureRect" type="Node2D"]
@@ -24,8 +24,8 @@ script = ExtResource("1_ug7y2")
 resize_properties = SubResource("Resource_nxr5t")
 
 [node name="TextureRect" type="TextureRect" parent="."]
-offset_left = -77.4019
-offset_top = -371.4
-offset_right = 72.5981
-offset_bottom = 372.6
+offset_left = -75.0
+offset_top = -75.0
+offset_right = 75.0
+offset_bottom = 75.0
 texture = ExtResource("1_6urua")

--- a/test/manual/resizable_texture_rect.tscn
+++ b/test/manual/resizable_texture_rect.tscn
@@ -7,15 +7,15 @@
 [sub_resource type="Resource" id="Resource_nxr5t"]
 resource_local_to_scene = true
 script = ExtResource("2_qagh0")
-expand_from_center = false
+expand_from_center = true
 resizable = true
-size = Vector2(694, 348)
-lock_x = false
+size = Vector2(150, 744)
+lock_x = true
 lock_x_value = 150
 lock_y = false
 lock_y_value = 150
 moveable = true
-position = Vector2(6.59863, -55.4)
+position = Vector2(-2.40186, 0.600006)
 drag_snap = Vector2(1, 1)
 
 [node name="ResizableTextureRect" type="Node2D"]
@@ -24,8 +24,8 @@ script = ExtResource("1_ug7y2")
 resize_properties = SubResource("Resource_nxr5t")
 
 [node name="TextureRect" type="TextureRect" parent="."]
-offset_left = -340.401
-offset_top = -229.4
-offset_right = 353.599
-offset_bottom = 118.6
+offset_left = -77.4019
+offset_top = -371.4
+offset_right = 72.5981
+offset_bottom = 372.6
 texture = ExtResource("1_6urua")

--- a/test/unit/test_editor_handles_control.gd
+++ b/test/unit/test_editor_handles_control.gd
@@ -32,7 +32,42 @@ func test_can_make_one():
 	var ehc = autofree(EditorHandlesControl.new(EditorHandles.new()))
 	assert_not_null(ehc)
 
+func test_lock_x_disables_handles():
+	var ehc = _new_editor_handles_control()
+	ehc.eh.lock_x = true
 
+	for key in ['tl', 'tr', 'cr', 'br', 'bl', 'cl']:
+		assert_true(ehc._handles[key].disabled, str(key, ' disabled'))
+
+
+func test_lock_x_disables_handles_when_set_before_instanced():
+	var eh = EditorHandles.new()
+	eh.lock_x = true
+	var ehc = _new_editor_handles_control(eh)
+
+	for key in ['tl', 'tr', 'cr', 'br', 'bl', 'cl']:
+		assert_true(ehc._handles[key].disabled, str(key, ' disabled'))
+
+
+func test_lock_y_disables_handles():
+	var ehc = _new_editor_handles_control()
+	ehc.eh.lock_y = true
+
+	for key in ['tl', 'ct', 'tr', 'br', 'cb', 'bl']:
+		assert_true(ehc._handles[key].disabled, str(key, ' disabled'))
+
+
+func test_lock_y_disables_handles_when_set_before_instanced():
+	var eh = EditorHandles.new()
+	eh.lock_y = true
+	var ehc = _new_editor_handles_control(eh)
+
+	for key in ['tl', 'ct', 'tr', 'br', 'cb', 'bl']:
+		assert_true(ehc._handles[key].disabled, str(key, ' disabled'))
+
+
+#region handle mouse detection
+# --------------------
 func test_when_moveable_center_handle_contains_mouse():
 	var ehc = _new_editor_handles_control()
 	ehc.position = Vector2(100, 100)
@@ -82,8 +117,24 @@ func test_when_not_resizable_side_handles_do_not_contain_mouse():
 
 	assert_false(ehc.do_handles_contain_mouse())
 
+func test_when_handle_disabled_handle_does_not_contain_mouse():
+	var ehc = _new_editor_handles_control()
+	ehc.is_being_edited = true
 
+	ehc.eh.size = Vector2(100, 100)
+	ehc.position = Vector2(100, 100)
 
+	ehc._handles.tl.disabled = true
+	ehc.queue_redraw()
+
+	# tl
+	_sender.mouse_motion(Vector2(50, 50)).wait_frames(5)
+	await _sender.idle
+
+	assert_false(ehc.do_handles_contain_mouse())
+
+# --------------------
+#endregion
 #region Resize edges
 # --------------------
 func _resize_sides_drag_handle_by(ehc, handle, movement):


### PR DESCRIPTION
When `lock_x` or `lock_y` are enabled, handles that wouldn't work are disabled.